### PR TITLE
Add Discord status rotator

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "tasks": {
+    "test": "pytest tests",
+    "build": "pip install -r requirements.txt",
+    "launch": "python src/main.py"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
+# Discord Status Rotator
 
+## Description
+
+This project is a Discord user account status rotator using the latest version of `discord.py-self`. The purpose of this project is to automatically rotate the status of a Discord user account at regular intervals. The project is designed to be readable, maintainable, and modularized, following principles such as DRY (Don't Repeat Yourself), KISS (Keep It Simple, Stupid), SOLID (Single Responsibility, Open/Closed, Liskov Substitution, Interface Segregation, Dependency Inversion), YAGNI (You Aren't Gonna Need It), and SoC (Separation of Concerns).
+
+## Setup and Running
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/StalkDevelopment/Discord-Status-Rotator.git
+   cd Discord-Status-Rotator
+   ```
+
+2. Install the required dependencies:
+   ```sh
+   pip install -r requirements.txt
+   ```
+
+3. Configure the bot by editing the `src/config.py` file with your Discord token and desired status rotation interval.
+
+4. Run the bot:
+   ```sh
+   python src/main.py
+   ```
+
+## Principles Followed
+
+### DRY (Don't Repeat Yourself)
+The code is designed to minimize repetition by using functions and classes to encapsulate reusable logic.
+
+### KISS (Keep It Simple, Stupid)
+The implementation is kept as simple as possible, avoiding unnecessary complexity.
+
+### SOLID
+- **Single Responsibility Principle**: Each class and function has a single responsibility.
+- **Open/Closed Principle**: The code is open for extension but closed for modification.
+- **Liskov Substitution Principle**: Subclasses can be substituted for their base classes without affecting the correctness of the program.
+- **Interface Segregation Principle**: Interfaces are designed to be small and specific to the needs of the client.
+- **Dependency Inversion Principle**: High-level modules do not depend on low-level modules; both depend on abstractions.
+
+### YAGNI (You Aren't Gonna Need It)
+The code includes only the functionality that is necessary for the current requirements, avoiding over-engineering.
+
+### SoC (Separation of Concerns)
+The code is organized into modules, each responsible for a specific aspect of the functionality, making it easier to understand and maintain.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+discord.py-self

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,7 @@
+# Configuration variables for Discord Status Rotator
+
+# Discord bot token
+TOKEN = 'your_discord_token_here'
+
+# Status rotation interval in seconds
+STATUS_ROTATION_INTERVAL = 3600

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,34 @@
+import discord
+import asyncio
+import itertools
+from src.config import TOKEN, STATUS_ROTATION_INTERVAL
+from src.statuses import get_next_status
+
+class StatusRotator:
+    def __init__(self, client, statuses, interval):
+        self.client = client
+        self.statuses = statuses
+        self.interval = interval
+        self.status_cycle = itertools.cycle(self.statuses)
+
+    async def rotate_status(self):
+        while True:
+            next_status = get_next_status(self.status_cycle)
+            await self.client.change_presence(activity=discord.Game(name=next_status))
+            await asyncio.sleep(self.interval)
+
+async def main():
+    intents = discord.Intents.default()
+    client = discord.Client(intents=intents)
+    statuses = ["Playing a game", "Listening to music", "Watching a movie"]
+
+    @client.event
+    async def on_ready():
+        print(f'Logged in as {client.user}')
+        rotator = StatusRotator(client, statuses, STATUS_ROTATION_INTERVAL)
+        await rotator.rotate_status()
+
+    await client.start(TOKEN)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/statuses.py
+++ b/src/statuses.py
@@ -1,0 +1,10 @@
+statuses = [
+    "Playing a game",
+    "Listening to music",
+    "Watching a movie",
+    "Coding a bot",
+    "Chatting with friends"
+]
+
+def get_next_status(status_cycle):
+    return next(status_cycle)

--- a/tests/test_status_rotator.py
+++ b/tests/test_status_rotator.py
@@ -1,0 +1,24 @@
+import unittest
+import asyncio
+from src.main import StatusRotator
+from unittest.mock import AsyncMock, MagicMock
+
+class TestStatusRotator(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.client = MagicMock()
+        self.statuses = ["Playing a game", "Listening to music", "Watching a movie"]
+        self.interval = 1
+        self.rotator = StatusRotator(self.client, self.statuses, self.interval)
+        self.rotator.status_cycle = iter(self.statuses)
+
+    async def test_rotate_status(self):
+        self.client.change_presence = AsyncMock()
+        task = asyncio.create_task(self.rotator.rotate_status())
+        await asyncio.sleep(3)
+        task.cancel()
+
+        self.client.change_presence.assert_any_call(activity=unittest.mock.ANY)
+        self.assertEqual(self.client.change_presence.call_count, 3)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_statuses.py
+++ b/tests/test_statuses.py
@@ -1,0 +1,19 @@
+import unittest
+from src.statuses import get_next_status, statuses
+import itertools
+
+class TestStatuses(unittest.TestCase):
+    def setUp(self):
+        self.status_cycle = itertools.cycle(statuses)
+
+    def test_get_next_status(self):
+        first_status = get_next_status(self.status_cycle)
+        second_status = get_next_status(self.status_cycle)
+        third_status = get_next_status(self.status_cycle)
+
+        self.assertEqual(first_status, statuses[0])
+        self.assertEqual(second_status, statuses[1])
+        self.assertEqual(third_status, statuses[2])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a Discord user account status rotator using the latest version of `discord.py-self`.

* **README.md**
  - Add project description, setup instructions, and principles followed (DRY, KISS, SOLID, YAGNI, SoC).

* **requirements.txt**
  - Add `discord.py-self` as a dependency.

* **src/main.py**
  - Import necessary modules (`discord`, `asyncio`, `itertools`).
  - Define `StatusRotator` class to handle status rotation.
  - Implement `main` function to run the bot.

* **src/statuses.py**
  - Define a list of statuses to rotate through.
  - Implement a function to get the next status.

* **src/config.py**
  - Define configuration variables (e.g., token, status rotation interval).

* **tests/test_status_rotator.py**
  - Import necessary modules (`unittest`, `asyncio`, `src.main`).
  - Implement unit tests for the `StatusRotator` class.

* **tests/test_statuses.py**
  - Import necessary modules (`unittest`, `src.statuses`).
  - Implement unit tests for the status rotation function.

* **.devcontainer.json**
  - Add devcontainer configuration for testing, building, and launching the project.

